### PR TITLE
Sync wireless debugging toggle

### DIFF
--- a/app/src/main/assets/actions.json
+++ b/app/src/main/assets/actions.json
@@ -30,6 +30,9 @@
           "sideEffects": {
             "onEnable": [
               { "settingType": "global", "key": "adb_wifi_enabled", "value": "1", "valueType": "int" }
+            ],
+            "onDisable": [
+              { "settingType": "global", "key": "adb_wifi_enabled", "value": "0", "valueType": "int" }
             ]
           }
         },

--- a/config/actions.json
+++ b/config/actions.json
@@ -30,6 +30,9 @@
           "sideEffects": {
             "onEnable": [
               { "settingType": "global", "key": "adb_wifi_enabled", "value": "1", "valueType": "int" }
+            ],
+            "onDisable": [
+              { "settingType": "global", "key": "adb_wifi_enabled", "value": "0", "valueType": "int" }
             ]
           }
         },


### PR DESCRIPTION
Ensure the USB Debugging action writes adb_wifi_enabled back to 0 when disabled so USB and wireless debugging stay in sync.